### PR TITLE
fix bug: empty string in AdditionaInfo triggers save

### DIFF
--- a/src/ui/table/additional/AdditionalInfoWidget.cpp
+++ b/src/ui/table/additional/AdditionalInfoWidget.cpp
@@ -29,7 +29,7 @@ AdditionalInfoWidget::AdditionalInfoWidget()
     connect(m_additionalInfoLineEdit, &QLineEdit::returnPressed, this, [this] {
         m_additionalInfoLineEdit->clearFocus();
         calculateWidth();
-        emit additionalInfoEdited();
+        if (this->getMainInfoText().toStdString() != "") emit additionalInfoEdited();
     });
 }
 


### PR DESCRIPTION
-empty string check hardcoded into AdditionInfoWidget to prevent emission of signal