### PR TITLE
Fix bug: empty or unaltered string in AdditionalInfoWidget triggers save on return keypress

### DIFF
--- a/src/ui/table/additional/AdditionalInfoWidget.cpp
+++ b/src/ui/table/additional/AdditionalInfoWidget.cpp
@@ -29,7 +29,9 @@ AdditionalInfoWidget::AdditionalInfoWidget()
     connect(m_additionalInfoLineEdit, &QLineEdit::returnPressed, this, [this] {
         m_additionalInfoLineEdit->clearFocus();
         calculateWidth();
-        emit additionalInfoEdited();
+        if (isValidEdit()) {
+            emit additionalInfoEdited();
+        }
     });
 }
 
@@ -97,9 +99,21 @@ AdditionalInfoWidget::calculateWidth()
 
 
 bool
+AdditionalInfoWidget::isValidEdit()
+{
+    const auto mainInfoText = getMainInfoText();
+    return !mainInfoText.isEmpty() && m_mainInfoTextCache != mainInfoText;
+}
+
+
+bool
 AdditionalInfoWidget::eventFilter(QObject* object, QEvent* event)
 {
     if (object == m_additionalInfoLineEdit && event->type() == QEvent::FocusIn) {
+        if (!m_isTextCacheLocked) {
+            m_mainInfoTextCache = getMainInfoText();
+            m_isTextCacheLocked = true;
+        }
         emit widgetCalled();
     }
     return false;

--- a/src/ui/table/additional/AdditionalInfoWidget.hpp
+++ b/src/ui/table/additional/AdditionalInfoWidget.hpp
@@ -54,6 +54,9 @@ private:
     calculateWidth();
 
     bool
+    isValidEdit();
+
+    bool
     eventFilter(QObject* object,
                 QEvent*  event) override;
 
@@ -64,7 +67,10 @@ private:
     QPointer<QLineEdit> m_additionalInfoLineEdit;
     QPointer<QLabel> m_statusEffectLabel;
     QPointer<QHBoxLayout> m_statusEffectsLayout;
+	
+    QString m_mainInfoTextCache;
 
+    bool m_isTextCacheLocked = false;
     int m_statusEffectsLayoutWidth = 0;
 
     QVector<AdditionalInfoData::StatusEffect> m_statusEffects;


### PR DESCRIPTION
- introduce new private variable `mainInfoTextCache`. It preserves the information of the `m_additionalInfoLineEdit `until the next render is triggered
- on new render, initialize `mainInfoTextCache = nullptr` to indicate, that the cache has to be set the next time the widget is focused. (using `mainInfoTextCache.isEmpty()` does not work, because `AdditionalInfoWidget `can be initialized with empty text, which would then prevent further input)
- introduce new private method `isValidEdit()->bool`, which checks if the line edit is empty or is it is equal `mainInfoTextCache `and is called when a save is triggered (return key pressed)
- prevent emission of signal if `isValidEdit()==false`